### PR TITLE
HC2 Scene: fix log error when failing to connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ local function request(requestUrl, deviceData)
         log("OK: " .. requestUrl .. " - " .. deviceData, "green")
       end,
       error = function (err)        
-        log("FAIL: " .. requestUrl .. " - " .. deviceData ". Error: " .. err, "red")
+        log("FAIL: " .. requestUrl .. " - " .. deviceData .. ". Error: " .. err, "red")
       end
     })
 end


### PR DESCRIPTION
A missing concatenation meant that instead of getting an error explaining what the connection problem is, we got an error like this:

`[DEBUG] 14:28:40: [1;31m2019-03-23 14:28:40.550683 [ fatal] LUA error: /opt/fibaro/scenes/193.lua:28: attempt to call upvalue 'deviceData' (a string value)
`
Signed-off-by: Adam Bewsher <adam.bewsher@neos.co.uk>